### PR TITLE
Fix linux building issues

### DIFF
--- a/released_plugins/build_plugindemo.sh
+++ b/released_plugins/build_plugindemo.sh
@@ -15,11 +15,11 @@ MYDIR=
 
 for arg in $*; do
   #echo $arg		
-  if [ $arg == "-m" ]; then
+  if [ "$arg" == "-m" ]; then
   	QMAKE_CONFIG="CONFIG+=x86_64"
-  elif [ $arg == "-n" ]; then
+  elif [ "$arg" == "-n" ]; then
   	QMAKE_CONFIG="CONFIG+=x86"
-  elif [ ${arg:0:2} == "-d" ]; then
+  elif [ "${arg:0:2}" == "-d" ]; then
   	MYDIR="${arg:2}"
   else
   	MAKE_ARGS+=" $arg"
@@ -36,7 +36,7 @@ fi
 # Need to define QMAKESPEC on Mac
 # because recent Qt installs default to creating xcode project files.
 # We want Makefiles for this script.
-if [[ `uname` == 'Darwin' ]]; then
+if [ `uname` = 'Darwin' ]; then
    QMAKE_ARGS='-spec macx-g++'
 else
    QMAKE_ARGS=''

--- a/v3d_main/build.redhat
+++ b/v3d_main/build.redhat
@@ -91,20 +91,24 @@ cd ../
 
 echo `pwd`
 
-if [ -e ../released_plugins_more ]; then
+if [ -d ../released_plugins_more ]; then
   cd ../released_plugins_more
   rm -fr v3d
-  sh build_plugindemo.sh $ARGS
+  bash build_plugindemo.sh $ARGS
   mkdir -p ../bin/plugins
-  cp -r v3d/plugins/* ../bin/plugins/.
+  # cp -r v3d/plugins/* ../bin/plugins/.
+else
+  echo "fail to find ../released_plugins_more"
 fi
 
 if [ -d ../released_plugins ]; then
   cd ../released_plugins
   rm -fr v3d
-  sh build_plugindemo.sh $ARGS
+  bash build_plugindemo.sh $ARGS
   mkdir -p ../bin/plugins
-  cp -r v3d/plugins/* ../bin/plugins/.
+  # cp -r v3d/plugins/* ../bin/plugins/.
+else
+  echo "fail to find ../released_plugins_more"
 fi
 
 cd ../v3d_main

--- a/v3d_main/build.redhat
+++ b/v3d_main/build.redhat
@@ -108,7 +108,7 @@ if [ -d ../released_plugins ]; then
   mkdir -p ../bin/plugins
   # cp -r v3d/plugins/* ../bin/plugins/.
 else
-  echo "fail to find ../released_plugins_more"
+  echo "fail to find ../released_plugins"
 fi
 
 cd ../v3d_main

--- a/v3d_main/terafly/teramanager.pro
+++ b/v3d_main/terafly/teramanager.pro
@@ -28,7 +28,7 @@ CONFIG += use_experimental_features
 
 
 #set up Vaa3D and Qt source path
-V3DMAINPATH =  ../
+V3DMAINPATH =  ..
 QT_PATH = $$dirname(QMAKE_QMAKE)/..
 
 #HDF5 headers and precompiled library and dependencies (libz and libszip)

--- a/v3d_main/v3d/v3d_essential.pro
+++ b/v3d_main/v3d/v3d_essential.pro
@@ -398,7 +398,8 @@ unix:!macx {
 }
 
 #added 20140324 to cope with centos 64bit GL library issue. by HP
-#unix:LIBS += -L/usr/lib64 -lGL
+#add -lglut -lGLU to fix the GL referencing issue on Ubuntu, otherwise it complains 
+unix:LIBS += -lglut -lGLU
 
 macx:LIBS += -L../common_lib/lib_mac32
 macx:LIBS += -lm -lv3dtiff -lv3dnewmat


### PR DESCRIPTION
1. Add -lglut -lGLU to v3d_main/build.redhat to bypass the broken link to glu*
2. Use bash to call `build_plugindemo.sh` in `v3d_main/build.redhat`. It otherwise causes interpretation errors
3. In `build_plugindemo.sh`, enclose $arg with `"`, otherwise bash generates noises like `-jN operator not defined`
4. Replace `[[` with `[` since `[[` is not compatible with modern shell interpretor

After the changes, v3d compiles on my newly installed Ubuntu flawlessly. 
