### PR TITLE
Updates to building with CMake

### DIFF
--- a/build.cmake
+++ b/build.cmake
@@ -118,6 +118,11 @@ fi
 
 case $OPERATION in
     install)
+        # See if the code is complete
+        if [[ ! -e v3d_main/terafly/src/terarepo/src ]]; then
+            echo "Missing the terafly repository. Did you do a git submodule command?"
+            exit 1
+        fi
         # See if the CMAKE_DIR is set
         if [ ! "$CMAKE_DIR" = "" ]; then
             if [[ -e $CMAKE_DIR ]]; then
@@ -162,12 +167,12 @@ case $OPERATION in
                     /c/Program\ Files/7-Zip/7z x -y boost_$BOOST_VERSION.tar
                 fi
                 cd boost_$BOOST_VERSION
-                cmd //c .\\bootstrap.bat
+                cmd //c .\\bootstrap.bat -without-libraries=python
                 cmd //c .\\b2.exe --toolset=msvc-12.0 address-model=64 --prefix=$boost_prefix install
             else
                 tar xzf $ROOT_DIR/v3d_main/common_lib/src_packages/boost_$BOOST_VERSION.tar.gz
                 cd boost_$BOOST_VERSION
-                ./bootstrap.sh --prefix=$boost_prefix
+                ./bootstrap.sh --prefix=$boost_prefix -without-libraries=python
                 ./b2 install
             fi
             cd ../../../../

--- a/v3d_main/3drenderer/GLee_r.h
+++ b/v3d_main/3drenderer/GLee_r.h
@@ -91,7 +91,7 @@ Peng, H, Ruan, Z., Atasoy, D., and Sternson, S. (2010) “Automatic reconstructi
 
 #endif
 
-#include "../../v3d/version_control.h"
+#include "../v3d/version_control.h"
 
 //yuy added _WIN6, 2010-05-19
 // #ifdef _WIN32 || _WIN64

--- a/v3d_main/3drenderer/ItemEditor.h
+++ b/v3d_main/3drenderer/ItemEditor.h
@@ -38,7 +38,7 @@ Peng, H, Ruan, Z., Atasoy, D., and Sternson, S. (2010) “Automatic reconstructi
 #ifndef ITEM_EDITOR_H_
 #define ITEM_EDITOR_H_
 
-#include "../../v3d/version_control.h"
+#include "../v3d/version_control.h"
 #if defined(USE_Qt5_VS2015_Win7_81) || defined(USE_Qt5_VS2015_Win10_10_14393)
   #include <QtWidgets>
   #include "qwidget.h"

--- a/v3d_main/3drenderer/v3dr_common.h
+++ b/v3d_main/3drenderer/v3dr_common.h
@@ -42,7 +42,7 @@ Peng, H, Ruan, Z., Atasoy, D., and Sternson, S. (2010) ?œAutomatic reconstructio
 #define V3DR_COMMON_H_
 
 // Added by MK, 11/21/2016, for migrating from VS2010/Qt4 to VS2015/Qt5
-#include "../../v3d/version_control.h"
+#include "../v3d/version_control.h"
 
 #if defined(USE_Qt5_VS2015_Win7_81) || defined(USE_Qt5_VS2015_Win10_10_14393)
   #include <QtWidgets>

--- a/v3d_main/CMakeLists.txt
+++ b/v3d_main/CMakeLists.txt
@@ -111,7 +111,7 @@ if(USE_FFMPEG)
 
     ExternalProject_Add(
         PKG-CONFIG-0-28
-        URL http://pkgconfig.freedesktop.org/releases/pkg-config-0.28.tar.gz
+        URL https://pkgconfig.freedesktop.org/releases/pkg-config-0.28.tar.gz
         SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/pkg-config/src
         INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/pkg-config/install
         UPDATE_COMMAND ""


### PR DESCRIPTION
I've begun updating the build process again for HHMI. Rather than have me commit to the trunk directly, I thought we'd try the standard open source method of pull requests.

These changes updates the internal cmake to 3.2 and separates out the major and minor versions so that downloads are simpler. It also will now check the system's cmake version, and download and build cmake if a lower version is found. It fixes a problem I had where the includes of the version_control header is one level of indirection to much, and it removes python when building the boost libraries.

Mark